### PR TITLE
Add document search bar to index page

### DIFF
--- a/assets/css/default_style.css
+++ b/assets/css/default_style.css
@@ -165,3 +165,26 @@ img {
   display: block;
   margin: 0 auto;
 }
+
+#search-container {
+    margin-bottom: 20px;
+}
+
+#search-input {
+    width: 100%;
+    padding: 8px;
+    font-size: 16px;
+    border: 1px solid #3c3c3c;
+    border-radius: 4px;
+    background-color: #1e1e1e;
+    color: #d4d4d4;
+}
+
+#search-results {
+    margin-top: 10px;
+}
+
+#search-results a {
+    display: block;
+    margin-bottom: 5px;
+}

--- a/assets/script/script.js
+++ b/assets/script/script.js
@@ -1,4 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
+    let allContents = [];
+
     fetch('directories.json')
         .then(response => response.json())
         .then(data => {
@@ -7,7 +9,42 @@ document.addEventListener('DOMContentLoaded', () => {
                 const sectionElement = createSectionElement(section);
                 container.appendChild(sectionElement);
             });
+            allContents = collectContents(data);
         });
+
+    const searchInput = document.getElementById('search-input');
+    const searchResults = document.getElementById('search-results');
+    searchInput.addEventListener('input', () => {
+        const query = searchInput.value.toLowerCase();
+        searchResults.innerHTML = '';
+        if (!query) {
+            return;
+        }
+        const matches = allContents.filter(item =>
+            item.content.toLowerCase().includes(query)
+        );
+        matches.forEach(item => {
+            const link = document.createElement('a');
+            link.href = item.link;
+            link.textContent = item.content;
+            link.classList.add('content-link');
+            searchResults.appendChild(link);
+            searchResults.appendChild(document.createElement('br'));
+        });
+    });
+
+    function collectContents(sections) {
+        let results = [];
+        sections.forEach(section => {
+            if (section.contents) {
+                results = results.concat(section.contents);
+            }
+            if (section.subsections) {
+                results = results.concat(collectContents(section.subsections));
+            }
+        });
+        return results;
+    }
 
     function createSectionElement(section) {
         const sectionDiv = document.createElement('div');

--- a/index.html
+++ b/index.html
@@ -14,6 +14,10 @@
 <a href="/cv" target="_blank" class="cv-link">
     <i class="fas fa-file-alt"></i> CV
 </a>
+<div id="search-container">
+    <input type="text" id="search-input" placeholder="Search documents by title...">
+    <div id="search-results"></div>
+</div>
 <!-- Sections will be dynamically added here -->
 <div id="sections-container"></div>
 <!-- Scripts -->


### PR DESCRIPTION
## Summary
- add search bar to index for quicker navigation of documents
- style search bar to match site theme
- implement JS to filter document titles and show matching links

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893b4088a948324ad83a2e9f79c384b