### PR TITLE
Enhance CV styling and highlight link on home

### DIFF
--- a/assets/css/cv_style.css
+++ b/assets/css/cv_style.css
@@ -1,9 +1,15 @@
 body {
-  align-items: center;
-  font-size: 10px;
-  font-family: 'Courier New', Courier, monospace;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
   background-color: #1e1e1e;
   color: #d4d4d4;
+  margin: 0;
+  line-height: 1.6;
+}
+
+main {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 20px;
 }
 
 h1, h2 {
@@ -12,37 +18,38 @@ h1, h2 {
 }
 
 h3 {
+  color: #9cdcfe;
+  margin-top: 30px;
   text-align: center;
-  font-size: 14px;
-  color: MidnightBlue;
 }
 
 h4 {
-  text-align: center;
-  font-size: 12px;
-  color: #9cdcfe;
-}
-
-/* Center the table on the page */
-table {
-  margin-left: auto;
-  margin-right: auto;
-  border-collapse: collapse;
-  border: none; /* Remove the external border of the table */
-}
-
-/* Center the text inside table headers and cells */
-th, td {
-  text-align: center;
-  vertical-align: middle;
-  padding: 10px; /* Adds padding inside cells */
-  border: 1px solid #3c3c3c; /* Add internal borders to table headers and cells */
-  font-size: 8px;
   color: #d4d4d4;
+  text-align: center;
+  font-weight: normal;
 }
 
-/* Optional: Adds style to headers (bold is default for <th>) */
-th {
-  font-weight: bold;
-  background-color: #333333;
+.cv-header {
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 20px 0;
+}
+
+th, td {
+  border: 1px solid #3c3c3c;
+  padding: 10px;
+  text-align: left;
+}
+
+tr:nth-child(even) {
+  background-color: #252526;
+}
+
+tr:nth-child(odd) {
+  background-color: #1e1e1e;
 }

--- a/assets/css/default_style.css
+++ b/assets/css/default_style.css
@@ -94,6 +94,33 @@ a.cv-link i {
   margin-right: 8px;
 }
 
+.cv-link-container {
+  display: flex;
+  justify-content: center;
+  margin: 20px 0;
+}
+
+.cv-button {
+  display: inline-flex;
+  align-items: center;
+  background-color: #009879;
+  color: #ffffff;
+  padding: 12px 24px;
+  border-radius: 8px;
+  text-decoration: none;
+  font-size: 18px;
+  transition: background-color 0.3s ease;
+}
+
+.cv-button:hover {
+  background-color: #007f67;
+  color: #ffffff;
+}
+
+.cv-button i {
+  margin-right: 8px;
+}
+
 /* Improved table styles */
 table {
   width: 100%;

--- a/cv.md
+++ b/cv.md
@@ -5,7 +5,8 @@ title: Resume
 
 # Matteo Moi - Senior Software Engineer
 
-<div align="center">
+
+<div class="cv-header">
 
 #### Location: Sondrio, Italy | Email: matteo.moi1998@gmail.com
 

--- a/index.html
+++ b/index.html
@@ -3,6 +3,10 @@ layout: default
 title: Jok98
 ---
 
+<div class="cv-link-container">
+  <a href="/cv" class="cv-button"><i class="fas fa-file-alt"></i> View My CV</a>
+</div>
+
 <h2>Notes & Resources</h2>
 
 <div id="search-container">


### PR DESCRIPTION
## Summary
- Revamp CV page with a cleaner dark theme, centered layout, and improved table styling.
- Add a prominent, centrally positioned CV button on the home page for easier access.
- Introduce shared button styles and layout rules to maintain consistent site aesthetics.

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893c8c8150c83248350c63e25c54f53