### PR TITLE
Enhance trip diary photo gallery

### DIFF
--- a/assets/css/default_style.css
+++ b/assets/css/default_style.css
@@ -231,3 +231,33 @@ img {
   display: block;
   margin-bottom: 5px;
 }
+/* Photo grid for trip diaries */
+.photo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 10px;
+  margin: 20px 0;
+}
+
+.photo-grid figure {
+  margin: 0;
+  background-color: #252526;
+  border: 1px solid #3c3c3c;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.photo-grid img {
+  width: 100%;
+  height: auto;
+  aspect-ratio: auto;
+  object-fit: cover;
+  display: block;
+}
+
+.photo-grid figcaption {
+  padding: 8px;
+  text-align: center;
+  font-size: 0.9em;
+  color: #d4d4d4;
+}

--- a/notes/other/trip/osaka_2024/diary.md
+++ b/notes/other/trip/osaka_2024/diary.md
@@ -3,77 +3,185 @@ layout: default
 title: Osaka 2024
 ---
 
-# 06/12/2024
+# Osaka 2024
 
-|                  |                                                                        |
-|------------------|------------------------------------------------------------------------|
-| Malpensa airport | ![Gate](../../../../assets/utils/trip/06_12_24/gate.jpg)                  |
-| To Beijing       | ![AirplaneToBeijing](../../../../assets/utils/trip/06_12_24/airplane.jpg) |
-| Airplane Food    | ![AirplaneFood](../../../../assets/utils/trip/06_12_24/airplane_food.jpg) |
-
----
-
-# 07/12/2024
-
-|                         |                                                                                 |
-|-------------------------|---------------------------------------------------------------------------------|
-| Beijing View            | ![BeijingView](../../../../assets/utils/trip/07_12_24/1_beijing_view.jpg)          |
-| Beijing Airoport Temple | ![Beijing](../../../../assets/utils/trip/07_12_24/2_beijing_airport_temple.jpg)    |
-| Sky view                | ![SkyViewToJapan](../../../../assets/utils/trip/07_12_24/3_sky_view_to_japan.jpg)  |
-| Welcome to Japan        | ![WelcomeToJapan](../../../../assets/utils/trip/07_12_24/4_welcome_to_japan.jpg)   |
-| Cypress Inn             | ![HotelCypressInn](../../../../assets/utils/trip/07_12_24/5_hotel_cypress_inn.jpg) |
-| First Katsukare         | ![Katsukare](../../../../assets/utils/trip/07_12_24/6_first_katsukare.jpg)         |
-| Shinkoiwa               | ![7_shinkoiwa](../../../../assets/utils/trip/07_12_24/7_shinkoiwa.jpg)             |
+## 06/12/2024
+<div class="photo-grid">
+  <figure markdown="1">
+  ![Gate](../../../../assets/utils/trip/06_12_24/gate.jpg)
+  <figcaption>Malpensa airport</figcaption>
+  </figure>
+  <figure markdown="1">
+  ![Airplane to Beijing](../../../../assets/utils/trip/06_12_24/airplane.jpg)
+  <figcaption>To Beijing</figcaption>
+  </figure>
+  <figure markdown="1">
+  ![Airplane Food](../../../../assets/utils/trip/06_12_24/airplane_food.jpg)
+  <figcaption>Airplane Food</figcaption>
+  </figure>
+</div>
 
 ---
 
-# 08/12/2024
-
-|             |                                                                            |
-|-------------|----------------------------------------------------------------------------|
-| Akihabara   | ![Akihabara](../../../../assets/utils/trip/08_12_24/1_akihabara_1.jpg)        |
-| Ufo catcher | ![UfoCatcher](../../../../assets/utils/trip/08_12_24/2_first_ufo_catcher.jpg) |
-| Akihabara   | ![Akihabara](../../../../assets/utils/trip/08_12_24/3_akihabara_2.jpg)        |
-| First Ramen | ![Ramen](../../../../assets/utils/trip/08_12_24/4_first_ramen.jpg)            |
-| Akihabara   | ![Akihabara](../../../../assets/utils/trip/08_12_24/5_akihabara_3.jpg)        |
+## 07/12/2024
+<div class="photo-grid">
+  <figure markdown="1">
+  ![Beijing View](../../../../assets/utils/trip/07_12_24/1_beijing_view.jpg)
+  <figcaption>Beijing View</figcaption>
+  </figure>
+  <figure markdown="1">
+  ![Beijing Airport Temple](../../../../assets/utils/trip/07_12_24/2_beijing_airport_temple.jpg)
+  <figcaption>Beijing Airport Temple</figcaption>
+  </figure>
+  <figure markdown="1">
+  ![Sky view to Japan](../../../../assets/utils/trip/07_12_24/3_sky_view_to_japan.jpg)
+  <figcaption>Sky view</figcaption>
+  </figure>
+  <figure markdown="1">
+  ![Welcome to Japan](../../../../assets/utils/trip/07_12_24/4_welcome_to_japan.jpg)
+  <figcaption>Welcome to Japan</figcaption>
+  </figure>
+  <figure markdown="1">
+  ![Hotel Cypress Inn](../../../../assets/utils/trip/07_12_24/5_hotel_cypress_inn.jpg)
+  <figcaption>Cypress Inn</figcaption>
+  </figure>
+  <figure markdown="1">
+  ![First Katsukare](../../../../assets/utils/trip/07_12_24/6_first_katsukare.jpg)
+  <figcaption>First Katsukare</figcaption>
+  </figure>
+  <figure markdown="1">
+  ![Shinkoiwa](../../../../assets/utils/trip/07_12_24/7_shinkoiwa.jpg)
+  <figcaption>Shinkoiwa</figcaption>
+  </figure>
+</div>
 
 ---
 
-# 09/12/2024
+## 08/12/2024
+<div class="photo-grid">
+  <figure markdown="1">
+  ![Akihabara](../../../../assets/utils/trip/08_12_24/1_akihabara_1.jpg)
+  <figcaption>Akihabara</figcaption>
+  </figure>
+  <figure markdown="1">
+  ![Ufo catcher](../../../../assets/utils/trip/08_12_24/2_first_ufo_catcher.jpg)
+  <figcaption>Ufo catcher</figcaption>
+  </figure>
+  <figure markdown="1">
+  ![Akihabara](../../../../assets/utils/trip/08_12_24/3_akihabara_2.jpg)
+  <figcaption>Akihabara</figcaption>
+  </figure>
+  <figure markdown="1">
+  ![First Ramen](../../../../assets/utils/trip/08_12_24/4_first_ramen.jpg)
+  <figcaption>First Ramen</figcaption>
+  </figure>
+  <figure markdown="1">
+  ![Akihabara](../../../../assets/utils/trip/08_12_24/5_akihabara_3.jpg)
+  <figcaption>Akihabara</figcaption>
+  </figure>
+</div>
 
-|                    |                                                                               |
-|--------------------|-------------------------------------------------------------------------------|
-| to fuji            | ![ToFuji](../../../../assets/utils/trip/09_12_24/1_to_fuji_1.jpg)                |
-| to fuji            | ![ToFuji](../../../../assets/utils/trip/09_12_24/2_to_fuji_2.jpg)                |
-| First view of Fuji | ![FirstViewOfFuji](../../../../assets/utils/trip/09_12_24/3_first_view_fuji.jpg) |
-| Square             | ![Square](../../../../assets/utils/trip/09_12_24/4_square_1.jpg)                 |
-| Square             | ![Square](../../../../assets/utils/trip/09_12_24/5_square_2.jpg)                 |
-| To the Pagoda      | ![ToThePagoda](../../../../assets/utils/trip/09_12_24/6_to_pagoda_1.jpg)         |
-| To the Pagoda      | ![ToThePagoda](../../../../assets/utils/trip/09_12_24/7_to_pagoda_2.jpg)         |
-| Fuji               | ![Fuji](../../../../assets/utils/trip/09_12_24/8_fuji_1.jpg)                     |
-| Fuji               | ![Fuji](../../../../assets/utils/trip/09_12_24/9_fuji_2.jpg)                     |
-| Pagoda             | ![Pagoda](../../../../assets/utils/trip/09_12_24/10_pagoda_1.jpg)                |
-| Pagoda             | ![Pagoda](../../../../assets/utils/trip/09_12_24/11_pagoda_2.jpg)                |
-| Fuji Pagoda        | ![FujiPagoda](../../../../assets/utils/trip/09_12_24/12_fuji_pagoda.jpg)         |
-| Fuji Pagoda        | ![FujiPagoda](../../../../assets/utils/trip/09_12_24/13_fuji_pagoda_2.jpg)       |
-| Fuji               | ![Fuji](../../../../assets/utils/trip/09_12_24/14_fuji_3.jpg)                    |
-| Fuji               | ![Fuji](../../../../assets/utils/trip/09_12_24/15_fuji_night.jpg)                |
-| Sushi              | ![Sushi](../../../../assets/utils/trip/09_12_24/16_sushi_sushiro.jpg)            |
+---
 
-# 10/12/2024
+## 09/12/2024
+<div class="photo-grid">
+  <figure markdown="1">
+  ![To Fuji](../../../../assets/utils/trip/09_12_24/1_to_fuji_1.jpg)
+  <figcaption>To Fuji</figcaption>
+  </figure>
+  <figure markdown="1">
+  ![To Fuji](../../../../assets/utils/trip/09_12_24/2_to_fuji_2.jpg)
+  <figcaption>To Fuji</figcaption>
+  </figure>
+  <figure markdown="1">
+  ![First view of Fuji](../../../../assets/utils/trip/09_12_24/3_first_view_fuji.jpg)
+  <figcaption>First view of Fuji</figcaption>
+  </figure>
+  <figure markdown="1">
+  ![Square](../../../../assets/utils/trip/09_12_24/4_square_1.jpg)
+  <figcaption>Square</figcaption>
+  </figure>
+  <figure markdown="1">
+  ![Square](../../../../assets/utils/trip/09_12_24/5_square_2.jpg)
+  <figcaption>Square</figcaption>
+  </figure>
+  <figure markdown="1">
+  ![To the Pagoda](../../../../assets/utils/trip/09_12_24/6_to_pagoda_1.jpg)
+  <figcaption>To the Pagoda</figcaption>
+  </figure>
+  <figure markdown="1">
+  ![To the Pagoda](../../../../assets/utils/trip/09_12_24/7_to_pagoda_2.jpg)
+  <figcaption>To the Pagoda</figcaption>
+  </figure>
+  <figure markdown="1">
+  ![Fuji](../../../../assets/utils/trip/09_12_24/8_fuji_1.jpg)
+  <figcaption>Fuji</figcaption>
+  </figure>
+  <figure markdown="1">
+  ![Fuji](../../../../assets/utils/trip/09_12_24/9_fuji_2.jpg)
+  <figcaption>Fuji</figcaption>
+  </figure>
+  <figure markdown="1">
+  ![Pagoda](../../../../assets/utils/trip/09_12_24/10_pagoda_1.jpg)
+  <figcaption>Pagoda</figcaption>
+  </figure>
+  <figure markdown="1">
+  ![Pagoda](../../../../assets/utils/trip/09_12_24/11_pagoda_2.jpg)
+  <figcaption>Pagoda</figcaption>
+  </figure>
+  <figure markdown="1">
+  ![Fuji Pagoda](../../../../assets/utils/trip/09_12_24/12_fuji_pagoda.jpg)
+  <figcaption>Fuji Pagoda</figcaption>
+  </figure>
+  <figure markdown="1">
+  ![Fuji Pagoda](../../../../assets/utils/trip/09_12_24/13_fuji_pagoda_2.jpg)
+  <figcaption>Fuji Pagoda</figcaption>
+  </figure>
+  <figure markdown="1">
+  ![Fuji](../../../../assets/utils/trip/09_12_24/14_fuji_3.jpg)
+  <figcaption>Fuji</figcaption>
+  </figure>
+  <figure markdown="1">
+  ![Fuji night](../../../../assets/utils/trip/09_12_24/15_fuji_night.jpg)
+  <figcaption>Fuji</figcaption>
+  </figure>
+  <figure markdown="1">
+  ![Sushi](../../../../assets/utils/trip/09_12_24/16_sushi_sushiro.jpg)
+  <figcaption>Sushi</figcaption>
+  </figure>
+</div>
 
-|            |                                                                     |
-|------------|---------------------------------------------------------------------|
-| Disneyland | ![Disneyland](../../../../assets/utils/trip/10_12_24/Disneyland_1.jpg) |
-| Disneyland | ![Disneyland](../../../../assets/utils/trip/10_12_24/Disneyland_2.jpg) |
-| Disneyland | ![Disneyland](../../../../assets/utils/trip/10_12_24/Disneyland_3.jpg) |
-| Disneyland | ![Disneyland](../../../../assets/utils/trip/10_12_24/Disneyland_4.jpg) |
-| Disneyland | ![Disneyland](../../../../assets/utils/trip/10_12_24/Disneyland_5.jpg) |
-| Disneyland | ![Disneyland](../../../../assets/utils/trip/10_12_24/Disneyland_6.jpg) |
-| Katsukare  | ![Disneyland](../../../../assets/utils/trip/10_12_24/katsukare.jpg)    |
+---
 
-
-
-
-
+## 10/12/2024
+<div class="photo-grid">
+  <figure markdown="1">
+  ![Disneyland](../../../../assets/utils/trip/10_12_24/Disneyland_1.jpg)
+  <figcaption>Disneyland</figcaption>
+  </figure>
+  <figure markdown="1">
+  ![Disneyland](../../../../assets/utils/trip/10_12_24/Disneyland_2.jpg)
+  <figcaption>Disneyland</figcaption>
+  </figure>
+  <figure markdown="1">
+  ![Disneyland](../../../../assets/utils/trip/10_12_24/Disneyland_3.jpg)
+  <figcaption>Disneyland</figcaption>
+  </figure>
+  <figure markdown="1">
+  ![Disneyland](../../../../assets/utils/trip/10_12_24/Disneyland_4.jpg)
+  <figcaption>Disneyland</figcaption>
+  </figure>
+  <figure markdown="1">
+  ![Disneyland](../../../../assets/utils/trip/10_12_24/Disneyland_5.jpg)
+  <figcaption>Disneyland</figcaption>
+  </figure>
+  <figure markdown="1">
+  ![Disneyland](../../../../assets/utils/trip/10_12_24/Disneyland_6.jpg)
+  <figcaption>Disneyland</figcaption>
+  </figure>
+  <figure markdown="1">
+  ![Katsukare](../../../../assets/utils/trip/10_12_24/katsukare.jpg)
+  <figcaption>Katsukare</figcaption>
+  </figure>
+</div>
 


### PR DESCRIPTION
## Summary
- redesign Osaka trip diary with a responsive photo grid
- add CSS styles for the gallery to improve photo presentation
- render gallery images with Markdown syntax to ensure they display on the diary page

## Testing
- `jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68941292d2b883248b7b493e3e95f424