### PR TITLE
feat: enhance site and CV styling

### DIFF
--- a/assets/css/cv_style.css
+++ b/assets/css/cv_style.css
@@ -1,6 +1,6 @@
 body {
-  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  background-color: #1e1e1e;
+  font-family: 'Roboto', 'Segoe UI', Tahoma, sans-serif;
+  background: linear-gradient(135deg, #1e1e1e 0%, #121212 100%);
   color: #d4d4d4;
   margin: 0;
   line-height: 1.6;
@@ -8,24 +8,27 @@ body {
 
 main {
   max-width: 900px;
-  margin: 0 auto;
-  padding: 20px;
+  margin: 20px auto;
+  padding: 20px 30px;
+  background-color: #252526;
+  border-radius: 10px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);
 }
 
-h1, h2 {
+h1,
+h2,
+h3,
+h4 {
   text-align: center;
   color: #9cdcfe;
 }
 
 h3 {
-  color: #9cdcfe;
   margin-top: 30px;
-  text-align: center;
 }
 
 h4 {
   color: #d4d4d4;
-  text-align: center;
   font-weight: normal;
 }
 
@@ -34,10 +37,23 @@ h4 {
   margin-bottom: 20px;
 }
 
+.cv-header a {
+  color: #009879;
+  text-decoration: none;
+  transition: color 0.3s ease;
+}
+
+.cv-header a:hover {
+  color: #00bfa6;
+}
+
 table {
   width: 100%;
   border-collapse: collapse;
   margin: 20px 0;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
 }
 
 th, td {
@@ -47,9 +63,21 @@ th, td {
 }
 
 tr:nth-child(even) {
-  background-color: #252526;
+  background-color: #2a2a2a;
 }
 
 tr:nth-child(odd) {
   background-color: #1e1e1e;
+}
+
+tr:hover {
+  background-color: #333333;
+}
+
+ul {
+  padding-left: 20px;
+}
+
+li {
+  margin-bottom: 5px;
 }

--- a/assets/css/default_style.css
+++ b/assets/css/default_style.css
@@ -1,12 +1,25 @@
 body {
-  font-family: "Courier New", Courier, monospace;
-  background-color: #1e1e1e;
+  font-family: 'Roboto', 'Segoe UI', Tahoma, sans-serif;
+  background: linear-gradient(135deg, #1e1e1e 0%, #121212 100%);
   color: #d4d4d4;
   margin: 0;
+  line-height: 1.6;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  color: #9cdcfe;
+  line-height: 1.3;
 }
 
 main {
   padding: 20px;
+  max-width: 1000px;
+  margin: 0 auto;
 }
 
 .navbar {
@@ -14,8 +27,9 @@ main {
   justify-content: space-between;
   align-items: center;
   padding: 10px 20px;
-  background-color: #333333;
+  background: linear-gradient(90deg, #333333, #222222);
   border-bottom: 1px solid #3c3c3c;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
 }
 
 .nav-logo {
@@ -33,18 +47,41 @@ main {
 .nav-link {
   color: #9cdcfe;
   text-decoration: none;
+  position: relative;
+  transition: color 0.3s ease;
+}
+
+.nav-link::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -4px;
+  width: 0;
+  height: 2px;
+  background: #007acc;
+  transition: width 0.3s ease;
 }
 
 .nav-link:hover {
-  color: #007acc;
+  color: #ffffff;
+}
+
+.nav-link:hover::after {
+  width: 100%;
 }
 
 .section {
   margin-bottom: 20px;
   background-color: #252526;
   border: 1px solid #3c3c3c;
-  border-radius: 5px;
-  padding: 5px 10px;
+  border-radius: 8px;
+  padding: 15px 20px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+  transition: transform 0.2s ease;
+}
+
+.section:hover {
+  transform: translateY(-2px);
 }
 
 .section > summary {
@@ -109,12 +146,14 @@ a.cv-link i {
   border-radius: 8px;
   text-decoration: none;
   font-size: 18px;
-  transition: background-color 0.3s ease;
+  transition: background-color 0.3s ease, transform 0.2s ease;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
 }
 
 .cv-button:hover {
   background-color: #007f67;
   color: #ffffff;
+  transform: translateY(-2px);
 }
 
 .cv-button i {
@@ -129,6 +168,9 @@ table {
   font-size: 1em;
   font-family: "Arial", sans-serif;
   color: #333;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
 }
 
 table thead tr {
@@ -161,6 +203,10 @@ table tbody tr:last-of-type {
   border-bottom: 2px solid #009879;
 }
 
+table tbody tr:hover {
+  background-color: #eaeaea;
+}
+
 /* Improved button styles */
 button {
   background-color: #009879;
@@ -174,11 +220,13 @@ button {
   margin: 4px 2px;
   cursor: pointer;
   border-radius: 8px;
-  transition: background-color 0.3s ease;
+  transition: background-color 0.3s ease, transform 0.2s ease;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
 }
 
 button:hover {
   background-color: #007f67;
+  transform: translateY(-2px);
 }
 
 /* Style for code snippets */


### PR DESCRIPTION
## Summary
- refresh default theme with modern fonts, gradients, and interactive hover effects
- restyle CV layout with card look, table shadows, and link accents

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_6894d342fa7c832483f54e2cff3f4f88